### PR TITLE
Fix hash value for decimals considered equal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,20 @@ impl FromStr for BigDecimal {
 
 impl Hash for BigDecimal {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.int_val.to_str_radix(10).trim_right_matches('0').hash(state);
+        let mut dec_str = self.int_val.to_str_radix(10).to_string();
+        let scale = self.scale;
+        let zero = self.int_val.is_zero();
+        if scale > 0 && !zero {
+                let mut cnt = 0;
+                dec_str = dec_str
+                    .trim_right_matches(|x| {
+                        cnt += 1;
+                        x == '0' && cnt <= scale
+                    }).to_string();
+        } else if scale < 0 && !zero {
+                dec_str.push_str(&"0".repeat(self.scale.abs() as usize));
+        }
+        dec_str.hash(state);
     }
 }
 
@@ -1307,12 +1320,73 @@ mod bigdecimal_tests {
             ("1.12340", "1.1234000000"),
             ("-0901300e-3", "-901.3"),
             ("-0.901300e+3", "-901.3"),
+            ("100", "100.00"),
+            ("100.00", "100"),
+            ("0.00", "0"),
+            ("0.00", "0.000"),
+            ("-0.00", "0.000"),
+            ("0.00", "-0.000"),
         ];
         for &(x,y) in vals.iter() {
             let a = BigDecimal::from_str(x).unwrap();
             let b = BigDecimal::from_str(y).unwrap();
             assert_eq!(a, b);
-            assert_eq!(hash(&a), hash(&b), "hash({}) == hash({})", a, b);
+            assert_eq!(hash(&a), hash(&b), "hash({}) != hash({})", a, b);
+        }
+    }
+
+    #[test]
+    fn test_hash_not_equal() {
+        use std::hash::{Hash, Hasher};
+        use std::collections::hash_map::DefaultHasher;
+
+        fn hash<T>(obj: &T) -> u64
+            where T: Hash
+        {
+            let mut hasher = DefaultHasher::new();
+            obj.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let vals = vec![
+            ("1.1234", "1.1234001"),
+            ("10000", "10"),
+            ("10", "10000"),
+            ("10.0", "100"),
+        ];
+        for &(x,y) in vals.iter() {
+            let a = BigDecimal::from_str(x).unwrap();
+            let b = BigDecimal::from_str(y).unwrap();
+            assert!(a != b, "{} == {}", a, b);
+            assert!(hash(&a) != hash(&b), "hash({}) == hash({})", a, b);
+        }
+    }
+
+    #[test]
+    fn test_hash_equal_scale() {
+        use std::hash::{Hash, Hasher};
+        use std::collections::hash_map::DefaultHasher;
+
+        fn hash<T>(obj: &T) -> u64
+            where T: Hash
+        {
+            let mut hasher = DefaultHasher::new();
+            obj.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let vals = vec![
+            ("1234.5678", -2, "1200", 0),
+            ("1234.5678", -2, "1200", -2),
+            ("1234.5678", 0, "1234.1234", 0),
+            ("1234.5678", -3, "1200", -3),
+            ("-1234", -2, "-1200", 0),
+        ];
+        for &(x,xs,y,ys) in vals.iter() {
+            let a = BigDecimal::from_str(x).unwrap().with_scale(xs);
+            let b = BigDecimal::from_str(y).unwrap().with_scale(ys);
+            assert_eq!(a, b);
+            assert_eq!(hash(&a), hash(&b), "hash({}) != hash({})", a, b);
         }
     }
 


### PR DESCRIPTION
Fixes #23

I added a test case to check equality of hash values and tried to fix the issue.

The hash value is now generated using the string representation of the number, stripping trailing zeroes. I don't know if this is the most efficient way to implement `Hash` for `BigDecimal`. I'm open for feedback. 🎢 