### PR TITLE
Update serde implementation to fix tests for serde_json:1.0.8 and above.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ sudo: false
 script:
   - cargo build --verbose
   - cargo test
-
+  - cargo test --features serde

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 [dependencies]
 num = { version = "0.1.42", default-features=false, features=["bigint"] }
 num-traits = "0.2"
-serde = { version = "1", optional = true }
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies.serde_json]
-version = "1"
+version = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -972,7 +972,7 @@ mod bigdecimal_serde {
         where
             D: de::Deserializer<'de>,
         {
-            d.deserialize_str(BigDecimalVisitor)
+            d.deserialize_any(BigDecimalVisitor)
         }
     }
 


### PR DESCRIPTION
See the release notes for https://github.com/serde-rs/json/releases/tag/v1.0.8
explaining the break in compatibility.