### PR TITLE
Add string-only feature to force the use of strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ serde = { version = "1.0", optional = true }
 
 [dev-dependencies.serde_json]
 version = "1.0"
+
+[features]
+string-only = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1521,12 +1521,23 @@ mod bigdecimal_serde {
         }
     }
 
+    #[cfg(not(feature = "string-only"))]
     impl<'de> de::Deserialize<'de> for BigDecimal {
         fn deserialize<D>(d: D) -> Result<Self, D::Error>
             where
                 D: de::Deserializer<'de>,
         {
             d.deserialize_any(BigDecimalVisitor)
+        }
+    }
+
+    #[cfg(feature = "string-only")]
+    impl<'de> de::Deserialize<'de> for BigDecimal {
+        fn deserialize<D>(d: D) -> Result<Self, D::Error>
+            where
+                D: de::Deserializer<'de>,
+        {
+            d.deserialize_str(BigDecimalVisitor)
         }
     }
 
@@ -1588,6 +1599,7 @@ mod bigdecimal_serde {
     }
 
     #[test]
+    #[cfg(not(feature = "string-only"))]
     fn test_serde_deserialize_int() {
         use traits::FromPrimitive;
 
@@ -1608,6 +1620,7 @@ mod bigdecimal_serde {
     }
 
     #[test]
+    #[cfg(not(feature = "string-only"))]
     fn test_serde_deserialize_f64() {
         use traits::FromPrimitive;
 


### PR DESCRIPTION
Some serialization formats like **bincode** don't support `deserialize_any` method. Since **bigdecimal** crate serializes values to strings only this improvement force to use strings for deserialization by activating `string-only` feature. It allows to use **bincode** for big decimals.