### PR TITLE
Add i128 feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,14 @@ script:
   - cargo build --verbose
   - cargo test
   - cargo test --features serde
+  - |
+    if [ $TRAVIS_RUST_VERSION != "1.16.0" && $TRAVIS_RUST_VERSION != "1.22.0" ]; then
+      cargo test --features i128
+    fi
+  - |
+    if [ $TRAVIS_RUST_VERSION != "1.16.0" && $TRAVIS_RUST_VERSION != "1.22.0" ]; then
+      cargo test --features serde,i128
+    fi
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,8 @@ num-integer = "0.1.39"
 num-traits = "0.2"
 serde = { version = "1.0", optional = true }
 
-[dev-dependencies.serde_json]
-version = "1.0"
+[dev-dependencies.serde_yaml]
+version = "0.8"
+
+[features]
+i128 = ["num-bigint/i128", "num-integer/i128", "num-traits/i128"]

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ bigdecimal-rs
 
 |travis-badge| |codecov-badge| |gitter-badge|
 
-Documenation_
+Documentation_
 
 Arbitrary precision decimal numbers implemented for rust.
 

--- a/examples/repeated_squares.rs
+++ b/examples/repeated_squares.rs
@@ -1,13 +1,11 @@
-
 extern crate bigdecimal;
 
 use bigdecimal::BigDecimal;
-use std::time::Instant;
 use std::str::FromStr;
+use std::time::Instant;
 
-fn main()
-{
-  //   let mut x = BigDecimal::from(1.1);
+fn main() {
+    //   let mut x = BigDecimal::from(1.1);
     let mut x = BigDecimal::from_str("1.1").unwrap();
     // for iter in 0..1_000_000 {
     for iter in 0..1_000 {
@@ -16,8 +14,10 @@ fn main()
         // x = x.take_and_square();
         let end = Instant::now();
         let usage = end - start;
-        println!("iter {} takes {} secs", iter, usage.as_secs() as f32 + usage.subsec_nanos() as f32 / 1.0e9);
+        println!(
+            "iter {} takes {} secs",
+            iter,
+            usage.as_secs() as f32 + usage.subsec_nanos() as f32 / 1.0e9
+        );
     }
 }
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,9 @@ use std::default::Default;
 use std::error::Error;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::iter::Sum;
 use std::num::{ParseFloatError, ParseIntError};
 use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
-use std::iter::Sum;
 use std::str::{self, FromStr};
 
 use num_bigint::{BigInt, ParseBigIntError, Sign, ToBigInt};
@@ -225,7 +225,7 @@ impl BigDecimal {
 
             // check for "leading zero" in remainder term; otherwise round
             if p < 10 * &r {
-              q += get_rounding_term(&r);
+                q += get_rounding_term(&r);
             }
 
             BigDecimal {
@@ -673,7 +673,7 @@ impl FromStr for BigDecimal {
     }
 }
 
-#[allow(deprecated)]  // trim_right_match -> trim_end_match
+#[allow(deprecated)] // trim_right_match -> trim_end_match
 impl Hash for BigDecimal {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let mut dec_str = self.int_val.to_str_radix(10).to_string();
@@ -947,7 +947,8 @@ impl<'a> AddAssign<&'a BigInt> for BigDecimal {
         match self.scale.cmp(&0) {
             Ordering::Equal => self.int_val += rhs,
             Ordering::Greater => self.int_val += rhs * ten_to_the(self.scale as u64),
-            Ordering::Less =>  { // *self += BigDecimal::new(rhs, 0)
+            Ordering::Less => {
+                // *self += BigDecimal::new(rhs, 0)
                 self.int_val *= ten_to_the((-self.scale) as u64);
                 self.int_val += rhs;
                 self.scale = 0;
@@ -1108,7 +1109,9 @@ impl<'a> SubAssign<&'a BigInt> for BigDecimal {
     fn sub_assign(&mut self, rhs: &BigInt) {
         match self.scale.cmp(&0) {
             Ordering::Equal => SubAssign::sub_assign(&mut self.int_val, rhs),
-            Ordering::Greater => SubAssign::sub_assign(&mut self.int_val, rhs * ten_to_the(self.scale as u64)),
+            Ordering::Greater => {
+                SubAssign::sub_assign(&mut self.int_val, rhs * ten_to_the(self.scale as u64))
+            }
             Ordering::Less => {
                 self.int_val *= ten_to_the((-self.scale) as u64);
                 SubAssign::sub_assign(&mut self.int_val, rhs);
@@ -1198,8 +1201,6 @@ impl<'a, 'b> Mul<&'a BigInt> for &'b BigDecimal {
         BigDecimal::new(value, self.scale)
     }
 }
-
-
 
 forward_val_assignop!(impl MulAssign for BigDecimal, mul_assign);
 
@@ -1488,14 +1489,14 @@ impl Signed for BigDecimal {
 
 impl Sum for BigDecimal {
     #[inline]
-    fn sum<I: Iterator<Item=BigDecimal>>(iter: I) -> BigDecimal {
+    fn sum<I: Iterator<Item = BigDecimal>>(iter: I) -> BigDecimal {
         iter.fold(Zero::zero(), |a, b| a + b)
     }
 }
 
 impl<'a> Sum<&'a BigDecimal> for BigDecimal {
     #[inline]
-    fn sum<I: Iterator<Item=&'a BigDecimal>>(iter: I) -> BigDecimal {
+    fn sum<I: Iterator<Item = &'a BigDecimal>>(iter: I) -> BigDecimal {
         iter.fold(Zero::zero(), |a, b| a + b)
     }
 }
@@ -1760,7 +1761,8 @@ impl From<f32> for BigDecimal {
             "{:.PRECISION$e}",
             n,
             PRECISION = ::std::f32::DIGITS as usize
-        )).unwrap()
+        ))
+        .unwrap()
     }
 }
 
@@ -1771,7 +1773,8 @@ impl From<f64> for BigDecimal {
             "{:.PRECISION$e}",
             n,
             PRECISION = ::std::f64::DIGITS as usize
-        )).unwrap()
+        ))
+        .unwrap()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1968,6 +1968,7 @@ mod bigdecimal_serde {
         }
     }
 
+    #[cfg(feature = "i128")]
     #[test]
     fn test_serde_deserialize_i128() {
         use std::i128;
@@ -1982,6 +1983,7 @@ mod bigdecimal_serde {
         }
     }
 
+    #[cfg(feature = "i128")]
     #[test]
     fn test_serde_deserialize_u128() {
         use std::u128;
@@ -2064,6 +2066,7 @@ mod bigdecimal_tests {
         }
     }
 
+    #[cfg(feature = "i128")]
     #[test]
     fn test_to_i128() {
         use std::i128;
@@ -2093,6 +2096,7 @@ mod bigdecimal_tests {
         }
     }
 
+    #[cfg(feature = "i128")]
     #[test]
     fn test_to_u128() {
         use std::u128;
@@ -2154,6 +2158,7 @@ mod bigdecimal_tests {
         }
     }
 
+    #[cfg(feature = "i128")]
     #[test]
     fn test_from_i128() {
         use std::i128;
@@ -2177,6 +2182,7 @@ mod bigdecimal_tests {
         }
     }
 
+    #[cfg(feature = "i128")]
     #[test]
     fn test_from_u128() {
         use std::u128;


### PR DESCRIPTION
Hi!

This PR adds an optional `i128` feature which enables conversions between BigDecimal and i128/u128. It also enables deserialization support for these types.

I also had to replace the `serde_json` test dependency with `serde_yaml` because of incomplete support of i128 in `serde_json`. `serde_json` recognized numeric values as Serde maps when the `arbitrary_precision` feature was enabled, which broke tests. `serde_yaml` had no such problems.