### PR TITLE
Fix f32 and f64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1798,6 +1798,7 @@ impl ToBigInt for BigDecimal {
 mod bigdecimal_serde {
     use super::BigDecimal;
     use serde::{de, ser};
+    use std::convert::TryFrom;
     use std::fmt;
 
     impl ser::Serialize for BigDecimal {
@@ -1844,7 +1845,7 @@ mod bigdecimal_serde {
         where
             E: de::Error,
         {
-            Ok(BigDecimal::from(value))
+            BigDecimal::try_from(value).map_err(|err| E::custom(format!("{}", err)))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1621,7 +1621,7 @@ impl Num for BigDecimal {
                     _ => exp,
                 };
 
-                (base, try!(i64::from_str(exp)))
+                (base, i64::from_str(exp)?)
             }
         };
 
@@ -1651,7 +1651,7 @@ impl Num for BigDecimal {
         };
 
         let scale = decimal_offset - exponent_value;
-        let big_int = try!(BigInt::from_str_radix(&digits, radix));
+        let big_int = BigInt::from_str_radix(&digits, radix)?;
 
         Ok(BigDecimal::new(big_int, scale))
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -193,7 +193,8 @@ macro_rules! impl_div_for_float_primitive {
                 } else if den < 0.0 && self.is_positive() {
                     -(self / -den)
                 } else {
-                    self / BigDecimal::from(den)
+                    // Unwrap is safe, because `is_nan` checked above
+                    self / BigDecimal::try_from(den).unwrap()
                 }
             }
         }
@@ -205,7 +206,7 @@ macro_rules! impl_div_for_float_primitive {
                 if self.is_nan() {
                     BigDecimal::zero()
                 } else {
-                    BigDecimal::from(self) / den
+                    BigDecimal::try_from(self).unwrap() / den
                 }
             }
         }
@@ -217,7 +218,7 @@ macro_rules! impl_div_for_float_primitive {
                 if self.is_nan() {
                     BigDecimal::zero()
                 } else {
-                    BigDecimal::from(self) / den
+                    BigDecimal::try_from(self).unwrap() / den
                 }
             }
         }


### PR DESCRIPTION
The crate doesn't always handle floats correctly. For example it can panic for `NaN` value in `From<f32>` implementation, but later it wrapped with `Some(_)` that will never work.

This PR fixes how the library works with floats and offers `TryFrom` implementation instead of `From`.

Also I've fixed some deprecation warnings.