### PR TITLE
Add round implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,12 +600,10 @@ impl BigDecimal {
 
         if digit <= 4 {
             self.with_scale(round_digits)
+        } else if bigint.is_negative() {
+            self.with_scale(round_digits) - BigDecimal::new(BigInt::from(1), round_digits)
         } else {
-            if bigint.is_negative() {
-                self.with_scale(round_digits) - BigDecimal::new(BigInt::from(1), round_digits)
-            } else {
-                self.with_scale(round_digits) + BigDecimal::new(BigInt::from(1), round_digits)
-            }
+            self.with_scale(round_digits) + BigDecimal::new(BigInt::from(1), round_digits)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -581,6 +581,35 @@ impl BigDecimal {
         return result;
     }
 
+    /// Return number rounded to round_digits precision after the decimal point
+    /// panic if self.digits() > 16
+    fn round(&self, round_digits: i64) -> BigDecimal {
+        let (bigint, decimal_part_digits) = self.as_bigint_and_exponent();
+        let need_to_round_digits = decimal_part_digits - round_digits;
+        if round_digits >= 0 && need_to_round_digits <= 0 {
+            return self.clone();
+        }
+
+        let mut number = bigint.to_i64().unwrap();
+        // avoid -1555 / 10 = -156
+        if number < 0 {
+            number = -number;
+        }
+        for _ in 0..(need_to_round_digits-1) {
+            number /= 10;
+        }
+        let digit = number % 10;
+        if digit <= 4 {
+            self.with_scale(round_digits)
+        } else {
+            if bigint.sign() == Sign::Minus {
+                self.with_scale(round_digits) - BigDecimal::new(BigInt::from(1), round_digits)
+            } else {
+                self.with_scale(round_digits) + BigDecimal::new(BigInt::from(1), round_digits)
+            }
+        }
+    }
+
     /// Return true if this number has zero fractional part (is equal
     /// to an integer)
     ///
@@ -2532,6 +2561,33 @@ mod bigdecimal_tests {
             let b = BigDecimal::from_str(y).unwrap();
             assert_eq!(a, b);
             assert_eq!(a.scale, b.scale);
+        }
+    }
+
+    #[test]
+    fn test_round() {
+        let test_cases = vec![
+            ("1.45", 1, "1.5"),
+            ("1.444445", 1, "1.4"),
+            ("1.44", 1, "1.4"),
+            ("0.444", 2, "0.44"),
+            ("0.0045", 2, "0.00"),
+            ("-1.555", 2, "-1.56"),
+            ("-1.555", 99, "-1.555"),
+            ("5.5", 0, "6"),
+            ("-1", -1, "0"),
+            ("5", -1, "10"),
+            ("44", -1, "40"),
+            ("44", -99, "0"),
+            ("1.4499999999", 1, "1.4"),
+            ("-1.4499999999", 1, "-1.4"),
+            ("1.449999999", 1, "1.4"),
+            ("-9999.444455556666", 10, "-9999.4444555567"),
+        ];
+        for &(x, digits, y) in test_cases.iter() {
+            let a = BigDecimal::from_str(x).unwrap();
+            let b = BigDecimal::from_str(y).unwrap();
+            assert_eq!(a.round(digits), b);
         }
     }
 


### PR DESCRIPTION
Fix #14, #59 

---

Same behavior as Python3/MySQL round()

The round implementation is as same as MySQL's ROUND()
if round digits < 15, round result is as same as python3 round