### PR TITLE
Add serde feature to cargo toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ version = "1.0"
 
 [features]
 string-only = []
+serde = ["serde"]


### PR DESCRIPTION
Looks like serde feature is presented in the code yet missed in cargo definition. This commit adds it to features block and enables optional serde dependency if feature enabled.