### PR TITLE
Update num-bigint and num-integer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ keywords = ["mathematics", "numerics", "decimal", "arbitrary-precision", "floati
 license = "MIT/Apache-2.0"
 
 [dependencies]
-num-bigint = "0.3"
-num-integer = "0.1.43"
+num-bigint = "0.4"
+num-integer = "0.1.44"
 num-traits = "0.2"
 serde = { version = "1.0", optional = true }
 
-[dev-dependencies.serde_json]
-version = "1.0"
+[dev-dependencies]
+serde_json = "1.0"
 
 [features]
 string-only = []


### PR DESCRIPTION
The version of `num-bigint` used by this package is out of date, requiring me to downgrade `num-bigint` to use the bigint-related functions in `bigdecimal-rs`. This PR updates `num-bigint`, and while I was at it I also updated `num-integer` and cleaned up the `dev-dependencies` section.