### PR TITLE
Fix incorrect handling of _ in decimal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1792,7 +1792,10 @@ impl Num for BigDecimal {
                 // copy all trailing characters after '.' into the digits string
                 digits.push_str(trail);
 
-                (digits, trail.len() as i64)
+                // count number of trailing digits
+                let trail_digits = trail.chars().filter(|c| *c != '_').count();
+
+                (digits, trail_digits as i64)
             }
         };
 
@@ -2174,7 +2177,7 @@ mod bigdecimal_tests {
             ("-170141183460469231731687303715884105728", -170141183460469231731687303715884105728),
             ("12.34", 12),
             ("3.14", 3),
-            ("50", 50),            
+            ("50", 50),
             ("0.001", 0),
         ];
         for (s, ans) in vals {
@@ -2190,7 +2193,7 @@ mod bigdecimal_tests {
             ("340282366920938463463374607431768211455", 340282366920938463463374607431768211455),
             ("12.34", 12),
             ("3.14", 3),
-            ("50", 50),            
+            ("50", 50),
             ("0.001", 0),
         ];
         for (s, ans) in vals {
@@ -3035,6 +3038,7 @@ mod bigdecimal_tests {
             ("1.23E+3", 123, -1),
             ("1.23E-8", 123, 10),
             ("-1.23E-10", -123, 12),
+            ("-1_1.2_2", -1122, 2),
         ];
 
         for &(source, val, scale) in vals.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3038,12 +3038,17 @@ mod bigdecimal_tests {
             ("1.23E+3", 123, -1),
             ("1.23E-8", 123, 10),
             ("-1.23E-10", -123, 12),
+            ("123_", 123, 0),
+            ("31_862_140.830_686_979", 31862140830686979, 9),
             ("-1_1.2_2", -1122, 2),
+            ("999.521_939", 999521939, 6),
+            ("679.35_84_03E-2", 679358403, 8),
+            ("271576662.__E4", 271576662, -4),
         ];
 
         for &(source, val, scale) in vals.iter() {
             let x = BigDecimal::from_str(source).unwrap();
-            assert_eq!(x.int_val.to_i32().unwrap(), val);
+            assert_eq!(x.int_val.to_i64().unwrap(), val);
             assert_eq!(x.scale, scale);
         }
     }


### PR DESCRIPTION
BigDecimal supports '_' chars as visual
seperators in number strings in the pre and
post "." parts of the number.

The counting of post "." digits however
counts all characters but it should exclude '_' chars.

The underscore support comes from BigDecimal's use of num-bigint
https://github.com/rust-num/num-bigint/blob/6f2b8e0fc218dbd0f49bebb8db2d1a771fe6bafa/src/biguint/convert.rs#L246

https://github.com/akubera/bigdecimal-rs/issues/100
