### PR TITLE
BUG: override default FromPrimitive implementation for u128 and i128

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1954,6 +1954,24 @@ impl From<u64> for BigDecimal {
     }
 }
 
+impl From<i128> for BigDecimal {
+    fn from(n: i128) -> Self {
+        BigDecimal {
+            int_val: BigInt::from(n),
+            scale: 0,
+        }
+    }
+}
+
+impl From<u128> for BigDecimal {
+    fn from(n: u128) -> Self {
+        BigDecimal {
+            int_val: BigInt::from(n),
+            scale: 0,
+        }
+    }
+}
+
 impl From<(BigInt, i64)> for BigDecimal {
     #[inline]
     fn from((int_val, scale): (BigInt, i64)) -> Self {
@@ -2020,6 +2038,16 @@ impl FromPrimitive for BigDecimal {
 
     #[inline]
     fn from_u64(n: u64) -> Option<Self> {
+        Some(BigDecimal::from(n))
+    }
+
+    #[inline]
+    fn from_i128(n: i128) -> Option<Self> {
+        Some(BigDecimal::from(n))
+    }
+
+    #[inline]
+    fn from_u128(n: u128) -> Option<Self> {
         Some(BigDecimal::from(n))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3313,4 +3313,14 @@ mod bigdecimal_tests {
     fn test_bad_string_only_decimal_and_exponent() {
         BigDecimal::from_str(".e4").unwrap();
     }
+
+    #[test]
+    fn test_from_i128() {
+       BigDecimal::from_i128(-368934881474191032320).unwrap();
+    }
+
+    #[test]
+    fn test_from_u128() {
+       BigDecimal::from_i128(668934881474191032320).unwrap();
+    }
 }


### PR DESCRIPTION
The default FromPrimitive implementation for `BigDecimal::from_u128` and `BigDecimal::from_i128` goes through `u64` and `i64` respectively, rendering the default implementation useless as any number greater than 64 bits won't be parseable into a 128 bit number. The default implementation currently used can be found here:

https://github.com/rust-num/num-traits/blob/4ac94b4136ea06d0bd0e1b8abe30c55a45acffdf/src/cast.rs#L476

I have overridden the default implementation so that this function actually works as intended.