### PR TITLE
Do not rebuild if default_precision would not change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,16 +28,15 @@ fn write_default_precision(outdir_path: &PathBuf, filename: &str) -> std::io::Re
 
     let default_precision_rs_path = outdir_path.join(filename);
 
-    let default_precision = format!("const DEFAULT_PRECISION: u64 = {default_prec};");
+    let default_precision = format!("const DEFAULT_PRECISION: u64 = {};", default_prec);
 
     // Rewriting the file if it already exists with the same contents
     // would force a rebuild.
     match std::fs::read_to_string(&default_precision_rs_path) {
         Ok(existing_contents) if existing_contents == default_precision => {},
         _ => {
-            let mut default_precision_rs = File::create(&default_precision_rs_path)
-                .expect("Could not create default_precision.rs");
-            write!(default_precision_rs, "{default_precision}")?;
+            std::fs::write(&default_precision_rs_path, default_precision)
+                    .expect("Could not write big decimal default-precision file");
         }
     };
 

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,6 @@
 
 
 use std::env;
-use std::fs::File;
-use std::io::Write;
 use std::path::PathBuf;
 
 fn main() -> std::io::Result<()> {


### PR DESCRIPTION
Closes https://github.com/akubera/bigdecimal-rs/issues/105, which explains the rationale for this fix

Here is a proposed patch to avoid rebuilding bigdecimal always

I tested locally with 

```
cargo test
cargo test
cargo test
..
```

With this patch the subsequent calls to `cargo test` do not force a rebuild