### PR TITLE
Fix build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,50 +1,24 @@
 #![allow(clippy::style)]
 
-extern crate autocfg;
-
 use std::env;
 use std::path::PathBuf;
 
-
-fn main() -> std::io::Result<()> {
+fn main() {
     let ac = autocfg::new();
     ac.emit_rustc_version(1, 70);
 
-    let outdir = match std::env::var_os("OUT_DIR") {
-        None => return Ok(()),
-        Some(outdir) => outdir,
-    };
-    let outdir_path = PathBuf::from(outdir);
+    let env_var = env::var("RUST_BIGDECIMAL_DEFAULT_PRECISION").unwrap_or_else(|_| "100".to_owned());
+    println!("cargo:rerun-if-env-changed=RUST_BIGDECIMAL_DEFAULT_PRECISION");
 
-    write_default_precision(&outdir_path, "default_precision.rs")?;
-    Ok(())
-}
+    let outdir = std::env::var_os("OUT_DIR").unwrap();
+    let rust_file_path = PathBuf::from(outdir).join("default_precision.rs");
 
-/// Create default_precision.rs, containg definition of constant DEFAULT_PRECISION
-fn write_default_precision(outdir_path: &PathBuf, filename: &str) -> std::io::Result<()>
-{
+    let default_prec: u32 = env_var
+        .parse::<std::num::NonZeroU32>()
+        .expect("$RUST_BIGDECIMAL_DEFAULT_PRECISION must be an integer > 0")
+        .into();
 
-    let default_prec = env::var("RUST_BIGDECIMAL_DEFAULT_PRECISION")
-        .map(|s| s.parse::<std::num::NonZeroU32>().expect("$RUST_BIGDECIMAL_DEFAULT_PRECISION must be an integer > 0"))
-        .map(|nz_num| nz_num.into())
-        .unwrap_or(100u32);
+    let rust_file_contents = format!("const DEFAULT_PRECISION: u64 = {};", default_prec);
 
-    let default_precision_rs_path = outdir_path.join(filename);
-
-    let default_precision = format!("const DEFAULT_PRECISION: u64 = {};", default_prec);
-
-    // Rewriting the file if it already exists with the same contents
-    // would force a rebuild.
-    match std::fs::read_to_string(&default_precision_rs_path) {
-        Ok(existing_contents) if existing_contents == default_precision => {},
-        _ => {
-            std::fs::write(&default_precision_rs_path, default_precision)
-                    .expect("Could not write big decimal default-precision file");
-        }
-    };
-
-    println!("cargo:rerun-if-changed={}", default_precision_rs_path.display());
-    println!("cargo:rerun-if-env-changed={}", "RUST_BIGDECIMAL_DEFAULT_PRECISION");
-
-    Ok(())
+    std::fs::write(rust_file_path, rust_file_contents).unwrap();
 }


### PR DESCRIPTION
I described here that build.rs will always trigger a rebuild on the second build (but then settle after that) https://github.com/akubera/bigdecimal-rs/issues/105#issuecomment-1644976911 and this PR fixes that issue.

The fix is just to remove the line `println!("cargo:rerun-if-changed={}", default_precision_rs_path.display());`
This line doesnt make any sense because the path is an output not an input.
We only want to rebuild if our inputs change not our outputs.

The line was originally introduced here: https://github.com/akubera/bigdecimal-rs/commit/b35a851246465f724fde83397ab257bbef48dd32
And then a workaround that missed the root cause was introduced here: https://github.com/akubera/bigdecimal-rs/pull/106/files

I also cleaned up the whole thing because it was way more complicated than it needed to be.