### PR TITLE
Release 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigdecimal"
-version = "0.4.2+dev"
+version = "0.4.2"
 authors = ["Andrew Kubera"]
 description = "Arbitrary precision decimal numbers"
 documentation = "https://docs.rs/bigdecimal"


### PR DESCRIPTION
I am proposing we make a patch release to get https://github.com/akubera/bigdecimal-rs/pull/110 out the door.
Its been causing a lot of compile time issues for me.