### PR TITLE
Add `get_scale` method to `BigDecimal` for efficient number type determination

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,11 +238,11 @@ impl BigDecimal {
     /// let a = BigDecimal::from(12345);  // No fractional part
     /// let b = BigDecimal::from_str("123.45").unwrap();  // Fractional part
     ///
-    /// assert_eq!(a.get_scale(), 0);
-    /// assert_eq!(b.get_scale(), 2);
+    /// assert_eq!(a.fractional_digit_count(), 0);
+    /// assert_eq!(b.fractional_digit_count(), 2);
     /// ```
     #[inline]
-    pub fn get_scale(&self) -> i64 {
+    pub fn fractional_digit_count(&self) -> i64 {
         self.scale
     }
 
@@ -2250,18 +2250,18 @@ mod bigdecimal_tests {
     use paste::paste;
 
     #[test]
-    fn test_get_scale() {
+    fn test_fractional_digit_count() {
         // Zero value
         let vals = BigDecimal::from(0);
-        assert_eq!(vals.get_scale(), 0);
+        assert_eq!(vals.fractional_digit_count(), 0);
 
         // Fractional part with trailing zeros
         let vals = BigDecimal::from_str("1.0").unwrap();
-        assert_eq!(vals.get_scale(), 1);
+        assert_eq!(vals.fractional_digit_count(), 1);
 
         // Fractional part
         let vals = BigDecimal::from_str("1.23").unwrap();
-        assert_eq!(vals.get_scale(), 2);
+        assert_eq!(vals.fractional_digit_count(), 2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2255,16 +2255,13 @@ mod bigdecimal_tests {
         let vals = BigDecimal::from(0);
         assert_eq!(vals.get_scale(), 0);
 
+        // Fractional part with trailing zeros
         let vals = BigDecimal::from_str("1.0").unwrap();
         assert_eq!(vals.get_scale(), 1);
 
         // Fractional part
         let vals = BigDecimal::from_str("1.23").unwrap();
         assert_eq!(vals.get_scale(), 2);
-
-        // Fractional part with trailing zeros
-        let c = BigDecimal::from_str("1.230").unwrap();
-        assert_eq!(c.get_scale(), 3);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,25 @@ impl BigDecimal {
         }
     }
 
+    /// Returns the scale of the BigDecimal
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bigdecimal::BigDecimal;
+    /// use std::str::FromStr;
+    ///
+    /// let a = BigDecimal::from(12345);  // No fractional part
+    /// let b = BigDecimal::from_str("123.45").unwrap();  // Fractional part
+    ///
+    /// assert_eq!(a.get_scale(), 0);
+    /// assert_eq!(b.get_scale(), 2);
+    /// ```
+    #[inline]
+    pub fn get_scale(&self) -> i64 {
+        self.scale
+    }
+
     /// Creates and initializes a `BigDecimal`.
     ///
     /// Decodes using `str::from_utf8` and forwards to `BigDecimal::from_str_radix`.
@@ -2229,6 +2248,24 @@ mod bigdecimal_tests {
     use num_traits::{ToPrimitive, FromPrimitive, Signed, Zero, One};
     use num_bigint;
     use paste::paste;
+
+    #[test]
+    fn test_get_scale() {
+        // Zero value
+        let vals = BigDecimal::from(0);
+        assert_eq!(vals.get_scale(), 0);
+
+        let vals = BigDecimal::from_str("1.0").unwrap();
+        assert_eq!(vals.get_scale(), 1);
+
+        // Fractional part
+        let vals = BigDecimal::from_str("1.23").unwrap();
+        assert_eq!(vals.get_scale(), 2);
+
+        // Fractional part with trailing zeros
+        let c = BigDecimal::from_str("1.230").unwrap();
+        assert_eq!(c.get_scale(), 3);
+    }
 
     #[test]
     fn test_sum() {


### PR DESCRIPTION
## Context
When utilizing the `bigdecimal` within the SQL parser, specifically in the context of `gluesql`, there's a desire to identify "1.0" as a float rather than an integer. [related PR](https://github.com/gluesql/gluesql/pull/1416)

The existing mechanism for determining the type was:
```rust
fn is_integer_representation(bigdecimal_val: &BigDecimal) -> bool {
  let bigdecimal_val_str = bigdecimal_val.abs().to_string();
  bigdecimal_val.abs().digits() == bigdecimal_val_str.len() as u64
}
```

This method, which converts the number to a string to determine its length, introduces unnecessary overhead and can be deemed inefficient.

## Solution
Introducing the `get_scale` method allows direct access to the scale of a `BigDecimal`, enabling users to efficiently determine if a number is an integer or has a fractional component. This change does not modify the existing `is_number()` function, which currently classifies "1.0" as an integer.

## Benefits
By providing direct access to the scale, users who wish to treat "1.0" as a float can easily implement this behavior. This update enhances the flexibility and efficiency for all users of the library.

## Note
Care has been taken to ensure backwards compatibility and adherence to the library's design principles.