### PR TITLE
Use exponential format for decimals with relatively large scale

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
       rust-features:
         type: string
         default: "--all-targets"
+      proptest-enable:
+        type: boolean
+        default: false
     docker:
       - image: rust:<< parameters.rust-version >>-<< parameters.debian-version >>
     environment:
@@ -25,9 +28,18 @@ jobs:
       - run:
           name: Rust Version
           command: rustc --version; cargo --version
+      - when:
+          condition: << parameters.proptest-enable >>
+          steps:
+          - run:
+              name: Enable Running Property Tests
+              command: scripts/bigdecimal-property-tests enable
+      - run:
+          name: Generate cargo.lock
+          command: cargo generate-lockfile
       - restore_cache:
           keys:
-            - bigdecimal-cargo-<< parameters.rust-version >>-{{ checksum "Cargo.toml" }}
+            - bigdecimal-cargo-<< parameters.rust-version >>-{{ checksum "Cargo.lock" }}
             - bigdecimal-cargo-
       - run:
           name: Check
@@ -35,7 +47,7 @@ jobs:
       - save_cache:
           paths:
             - /usr/local/cargo
-          key: bigdecimal-cargo-<< parameters.rust-version >>-{{ checksum "Cargo.toml" }}
+          key: bigdecimal-cargo-<< parameters.rust-version >>-{{ checksum "Cargo.lock" }}
       - run:
           name: Build
           command: cargo build << parameters.rust-features >>
@@ -117,6 +129,10 @@ workflows:
         name: "lint-test-build:1.56"
         release: true
         version: "1.56"
+        pre-steps:
+            - checkout
+            - run:
+                command: cargo generate-lockfile
 
     - lint-check
 
@@ -137,6 +153,7 @@ workflows:
     - build-and-test:
         name: build-and-test:latest:serde
         rust-features: "--all-targets --features='serde'"
+        proptest-enable: true
 
     - build-and-test:
         name: build-and-test:no_std


### PR DESCRIPTION
This PR is related to some of the comments in #108, but there is not a specific issue created separately for this. Please let me know if you want me to create an issue first for some discussion.

---------

The first commit of the PR is mostly just adding tests to capture the current behavior.

The second commit is the more important, it adds a different formatting code path to the `fmt::Display` impl, so that numbers that have a large (absolute) scale relative to their integer representation length will be displayed in exponential format. The second commit message has more detail.

I chose the `(abs_int.len() as i64 - self.scale - 1)` as the criteria for the cutoff because I didn't want it to trigger only based on the `scale`. I imagined a scenario where the scale is large (either negative or positive), but it is inflated because the `int_val` has a large number of digits.

I'm specifically targeting cases where someone could input a small string like `1E100000` and then crash a program by making it do a huge allocation.

---------

Thanks for making and maintaining the `bigdecimal` crate! We find it very useful