### PR TITLE
Remove dev scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,14 @@ categories = [ "mathematics", "science", "no-std" ]
 license = "MIT/Apache-2.0"
 autobenches = false
 edition = "2015"
+include = [
+	'Cargo.toml',
+	'build.rs',
+        'LICENSE-APACHE',
+        'LICENSE-MIT',
+        'src/**/*.rs',
+        'README.md',
+]
 
 [lib]
 bench = false


### PR DESCRIPTION
During a dependency review we noticed that the bigdecimal crate contains dev scripts that are not required for compiling the crate as dependency. To reduce the potential surface for executing malicous scripts its better to just exclude such scripts from the published package.