### PR TITLE
Bump siphasher to 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde_json = { version = "1.0", optional = true, default-features = false, featu
 [dev-dependencies]
 paste = "1"
 serde_test = "<1.0.176"
-siphasher = { version = "0.3.10", default-features = false }
+siphasher = { version = "1", default-features = false }
 # The following dev-dependencies are only required for benchmarking
 #   (use the `benchmark-bigdecimal` script to uncomment these and run benchmarks)
 # BENCH: criterion = { version = "0.4", features = [ "html_reports" ] }


### PR DESCRIPTION
There don't seem to have been any API changes
(https://github.com/jedisct1/rust-siphash/compare/0.3.11...1.0.0), but since 1.0.0 was released in 2023 it seems better to depend on it to allow newer versions.